### PR TITLE
fix restoring algorithm

### DIFF
--- a/secret_backend/config.py
+++ b/secret_backend/config.py
@@ -87,8 +87,8 @@ def getLatestBackupfromS3():
                         if tag['Key'] == "datetime_created":
                             obj_date = datetime.fromisoformat(tag['Value'])
                             break
-                    if obj['Key'].endswith('.snap') and obj['Key'].split("/")[-1] == restore_this_backup:
-                        print("restoring this backup",restore_this_backup)
+                    if obj['Key'].endswith('.snap') and os.path.basename(obj['Key']) == restore_this_backup:
+                        logger.info(f"Restoring this backup: {restore_this_backup}")
                         return obj
                     if obj['Key'].endswith('.snap') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
                         latest_snap_object['date'] = obj_date

--- a/secret_backend/config.py
+++ b/secret_backend/config.py
@@ -79,18 +79,17 @@ def getLatestBackupfromS3():
         for page in page_iterator:
             if "Contents" in page:
                 for obj in page['Contents']:
-                    response = client.get_object_tagging(
+                    response = s3.get_object_tagging(
                         Bucket=bucket_name,
-                        Key=f"{captain_domain}/{backup_prefix}/{obj['Key']}",
+                        Key=obj['Key'],
                     )
                     for tag in response['TagSet']:
                         if tag['Key'] == "datetime_created":
                             obj_date = datetime.fromisoformat(tag['Value'])
                             break
-                    
-                    if obj['Key'].endswith('.snap') and obj['Key'] == restore_this_backup:
+                    if obj['Key'].endswith('.snap') and obj['Key'].split("/")[-1] == restore_this_backup:
+                        print("restoring this backup",restore_this_backup)
                         return obj
-
                     if obj['Key'].endswith('.snap') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
                         latest_snap_object['date'] = obj_date
                         latest_snap_object['obj'] = obj


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix S3 object tagging retrieval in backup restore function

- Correct backup file key comparison logic for restoration

- Add debug print when restoring a specific backup


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Fix S3 backup restore logic and key comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

secret_backend/config.py

<li>Use correct S3 client for object tagging retrieval<br> <li> Fix key comparison to match only backup filename, not full path<br> <li> Add debug print statement for restoration process<br> <li> Remove redundant code and improve logic clarity


</details>


  </td>
  <td><a href="https://github.com/GlueOps/vault-init-controller/pull/118/files#diff-3e586cff2ea8e5c37a748d23c8b6705bcb023df8cb435279d7684d1e2112c0d9">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>