### PR TITLE
chore: Remove old image cleanup step from workflow

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -57,11 +57,3 @@ jobs:
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Cleanup old images
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
-        with:
-          exclude-tags: latest,main,v*
-          keep-n-tagged: 5
-          delete-untagged: true
-          delete-partial-images: true


### PR DESCRIPTION
Removed the cleanup step for old images from the workflow.