### PR TITLE
feat: extend backup restore lookback to 185 days #minor

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -6,7 +6,7 @@ Backup keys follow `{CAPTAIN_DOMAIN}/{BACKUP_PREFIX}/{YYYY-MM-DD}/vault_{YYYY-MM
 
 ## Day-by-day reverse search
 
-`_findLatestBackup` searches from today backward (up to 45 days) using date-scoped S3 prefixes (e.g. `{domain}/{prefix}/2026-03-16/`). This avoids listing the entire backup history. In the common case (backups exist today), it's a single S3 API call.
+`_findLatestBackup` searches from today backward (up to 185 days) using date-scoped S3 prefixes (e.g. `{domain}/{prefix}/2026-03-16/`). This avoids listing the entire backup history. In the common case (backups exist today), it's a single S3 API call.
 
 ## Key format validation is safety-critical
 

--- a/secret_backend/config.py
+++ b/secret_backend/config.py
@@ -130,7 +130,7 @@ def _findSpecificBackup(paginator):
 
 def _findLatestBackup(paginator):
     today = datetime.utcnow().date()
-    for days_ago in range(45):
+    for days_ago in range(185):
         target_date = today - timedelta(days=days_ago)
         date_prefix = f"{captain_domain}/{backup_prefix}/{target_date.isoformat()}/"
         page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=date_prefix)

--- a/tests/test_backup_lookup.py
+++ b/tests/test_backup_lookup.py
@@ -88,8 +88,8 @@ class TestFindLatestBackupSuccess:
         result = _findLatestBackup(paginator)
         assert result["Key"] == key
 
-    def test_day_44_boundary_included(self):
-        target_date = date(2026, 1, 31)  # 44 days before 2026-03-16
+    def test_day_184_boundary_included(self):
+        target_date = date(2025, 9, 13)  # 184 days before 2026-03-16
         key = f"{DOMAIN}/{PREFIX}/{target_date.isoformat()}/vault_{target_date.isoformat()}T12:00:00.snap"
         paginator = make_paginator_by_prefix({
             f"{DOMAIN}/{PREFIX}/{target_date.isoformat()}/": [{"Contents": [make_snap_obj(key)]}],
@@ -103,12 +103,12 @@ class TestFindLatestBackupSuccess:
         call_args = [c.kwargs["Prefix"] for c in paginator.paginate.call_args_list]
         assert call_args[0] == f"{DOMAIN}/{PREFIX}/2026-03-16/"
         assert call_args[1] == f"{DOMAIN}/{PREFIX}/2026-03-15/"
-        assert call_args[-1] == f"{DOMAIN}/{PREFIX}/2026-01-31/"
-        assert len(call_args) == 45
+        assert call_args[-1] == f"{DOMAIN}/{PREFIX}/2025-09-13/"
+        assert len(call_args) == 185
 
 
 class TestFindLatestBackupFailure:
-    def test_no_backups_in_45_days(self):
+    def test_no_backups_in_185_days(self):
         paginator = make_paginator_by_prefix({})
         result = _findLatestBackup(paginator)
         assert result is None


### PR DESCRIPTION
## What

Extends the backup-restore lookback window in `_findLatestBackup` from **45 days → 185 days** (~6 months).

## Why

`_findLatestBackup` walks backward day-by-day from today, probing date-scoped S3 prefixes (`{domain}/{prefix}/YYYY-MM-DD/`) and returning the newest `.snap` from the first day that has one. Previously it gave up after 45 days — so if the newest backup was older than 45 days, it was silently treated as **"no backup found"**. Widening to 185 days means an older-but-valid backup is still discovered and restored.

## Behavior / cost

The loop stops at the first day with a hit, so:

| Scenario | Old (45) | New (185) | Extra calls |
|---|---|---|---|
| Backup exists today (common case) | 1 | 1 | **0** |
| Newest backup N days old (N ≤ 44) | N+1 | N+1 | **0** |
| No backup anywhere in window (worst case) | 45 | 185 | **+140** (~4.1×) |

Only a permanently-empty/misconfigured bucket pays the full 185 cheap `list_objects_v2` calls per reconcile cycle. Normal operation (a recent backup) is unaffected.

## Tests

Updated `tests/test_backup_lookup.py` boundary assertions (day-184 boundary `2025-09-13`, prefix count `185`) and renamed the affected tests. Also updated the `.ai/architecture.md` prose.

Full suite run via the Dockerfile `test` stage (same as CI): **43 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)